### PR TITLE
Folder path for pages needs to be quoted in additional single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ pages: ""
 Get all notes in obsidian.
 
 ```
-pages: "Notes/Theology"
+pages: '"Notes/Theology"'
 ```
 Set a custom folder to get notes from.
+
+*In order to set a custom folder that is passed to pages, the folder path needs to be passed including the double quotes either by enclosing them in single quotes as shown above or by escaping the double quotes like this:  "/"Notes/Theology/"".*
     
 ---
 ### view:


### PR DESCRIPTION
Without that change, the script will display the following error:

Dataview: Failed to execute view 'Main/NotesList/view.js'.

Error: Failed to parse query in 'pagePaths': Error:  -- PARSING FAILED --------------------------------------------------

> 1 | Notes/Theology
    | ^

Expected one of the following: 

'!', '(', '-', 'csv(', 'outgoing(', file link, string, tag ('#hello/stuff')